### PR TITLE
Syncing copyright blocks at top of each file

### DIFF
--- a/docs/src/benchmarks/__main__.py
+++ b/docs/src/benchmarks/__main__.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import os
 

--- a/docs/src/benchmarks/common.py
+++ b/docs/src/benchmarks/common.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 from trackstar.benchmarks import benchmark

--- a/docs/src/benchmarks/dimensionality.py
+++ b/docs/src/benchmarks/dimensionality.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import matplotlib.pyplot as plt

--- a/docs/src/benchmarks/index.rst
+++ b/docs/src/benchmarks/index.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 Benchmarks
 ==========

--- a/docs/src/benchmarks/nthreads.py
+++ b/docs/src/benchmarks/nthreads.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import matplotlib.pyplot as plt

--- a/docs/src/benchmarks/samplesize.py
+++ b/docs/src/benchmarks/samplesize.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import matplotlib.pyplot as plt

--- a/docs/src/benchmarks/tracksize.py
+++ b/docs/src/benchmarks/tracksize.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import matplotlib.pyplot as plt

--- a/docs/src/clib/index.rst
+++ b/docs/src/clib/index.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at: https://github.com/giganano/trackstar.git.
+.. at: https://github.com/giganano/TrackStar.git.
 
 C Library
 =========

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 #
 # Configuration file for sphinx documentation builder.
 

--- a/docs/src/developers/bug_reports.rst
+++ b/docs/src/developers/bug_reports.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 Submitting a Bug Report
 =======================

--- a/docs/src/developers/contributing/benchmarking.rst
+++ b/docs/src/developers/contributing/benchmarking.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 Benchmarking New Features
 +++++++++++++++++++++++++

--- a/docs/src/developers/contributing/index.rst
+++ b/docs/src/developers/contributing/index.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 Contributing to TrackStar
 =========================

--- a/docs/src/developers/contributors.rst
+++ b/docs/src/developers/contributors.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 .. _contributors:
 

--- a/docs/src/developers/license.rst
+++ b/docs/src/developers/license.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 .. _license:
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 .. _frontpage:
 

--- a/docs/src/science-documentation.rst
+++ b/docs/src/science-documentation.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 .. _science_documentation:
 

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -1,7 +1,7 @@
 .. This file is part of the TrackStar package.
 .. Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 .. License: MIT License. See LICENSE in top-level directory
-.. at https://github.com/giganano/trackstar.git.
+.. at https://github.com/giganano/TrackStar.git.
 
 .. _tutorials:
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 #
 # TrackStar adopts the PEP 517 standard procedure for distribution, which is
 # based on the project.toml file in this directory. This setup file compiles

--- a/trackstar/__init__.py
+++ b/trackstar/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 r"""
 TrackStar
 =========

--- a/trackstar/benchmarks/__init__.py
+++ b/trackstar/benchmarks/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["benchmark"]
 from .benchmark import benchmark

--- a/trackstar/benchmarks/__main__.py
+++ b/trackstar/benchmarks/__main__.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .discovery import discover_benchmarks
 import sys

--- a/trackstar/benchmarks/benchmark.py
+++ b/trackstar/benchmarks/benchmark.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["benchmark"]
 import timeit

--- a/trackstar/benchmarks/discovery.py
+++ b/trackstar/benchmarks/discovery.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 from .benchmark import benchmark_function, benchmark_class

--- a/trackstar/core/__init__.py
+++ b/trackstar/core/__init__.py
@@ -1,7 +1,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["matrix", "covariance_matrix", "datum", "track", "sample",
 	"openmp_linked"]

--- a/trackstar/core/benchmarks/__init__.py
+++ b/trackstar/core/benchmarks/__init__.py
@@ -3,5 +3,5 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 

--- a/trackstar/core/benchmarks/benchmark_covariance_matrix.py
+++ b/trackstar/core/benchmarks/benchmark_covariance_matrix.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar.benchmarks import benchmark
 from trackstar.core.tests.test_datum import _TEST_DATUM_

--- a/trackstar/core/benchmarks/benchmark_datum.py
+++ b/trackstar/core/benchmarks/benchmark_datum.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar.benchmarks import benchmark
 from trackstar.core.tests.test_datum import _TEST_DATUM_

--- a/trackstar/core/benchmarks/benchmark_matrix.py
+++ b/trackstar/core/benchmarks/benchmark_matrix.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar.benchmarks import benchmark
 from trackstar import matrix

--- a/trackstar/core/covariance_matrix.pxd
+++ b/trackstar/core/covariance_matrix.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .matrix cimport MATRIX, matrix, matrix_invert
 

--- a/trackstar/core/covariance_matrix.pyx
+++ b/trackstar/core/covariance_matrix.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["covariance_matrix"]
 import textwrap

--- a/trackstar/core/datum.pxd
+++ b/trackstar/core/datum.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .covariance_matrix cimport COVARIANCE_MATRIX, covariance_matrix
 from .matrix cimport MATRIX, matrix

--- a/trackstar/core/datum.pyx
+++ b/trackstar/core/datum.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["datum"]
 import numbers

--- a/trackstar/core/matrix.pxd
+++ b/trackstar/core/matrix.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 cdef extern from "./src/matrix.h":
 	ctypedef struct MATRIX:

--- a/trackstar/core/matrix.pyx
+++ b/trackstar/core/matrix.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["matrix"]
 import numbers

--- a/trackstar/core/multithread.pxd
+++ b/trackstar/core/multithread.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 cdef extern from "./src/multithread.h":
 	unsigned short multithreading_enabled()

--- a/trackstar/core/multithread.pyx
+++ b/trackstar/core/multithread.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["openmp_linked"]
 from . cimport multithread

--- a/trackstar/core/sample.pxd
+++ b/trackstar/core/sample.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .datum cimport DATUM, datum
 from .track cimport TRACK

--- a/trackstar/core/sample.pyx
+++ b/trackstar/core/sample.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["sample"]
 import math as m

--- a/trackstar/core/tests/test_covariance_matrix.py
+++ b/trackstar/core/tests/test_covariance_matrix.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar import datum, covariance_matrix
 from trackstar.core.datum import datum_extra

--- a/trackstar/core/tests/test_datum.py
+++ b/trackstar/core/tests/test_datum.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar import datum, covariance_matrix
 from trackstar.core.datum import datum_extra

--- a/trackstar/core/tests/test_matrix.py
+++ b/trackstar/core/tests/test_matrix.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar import matrix
 import numpy as np

--- a/trackstar/core/track.pxd
+++ b/trackstar/core/track.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .matrix cimport MATRIX
 

--- a/trackstar/core/track.pyx
+++ b/trackstar/core/track.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 __all__ = ["track"]
 import numbers

--- a/trackstar/core/utils.pxd
+++ b/trackstar/core/utils.pxd
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 cdef extern from "./src/utils.h":
 	signed short strindex(char **strlist, char *test,

--- a/trackstar/core/utils.pyx
+++ b/trackstar/core/utils.pyx
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 try:
 	# NumPy compatible but not NumPy dependent

--- a/trackstar/docs/__main__.py
+++ b/trackstar/docs/__main__.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 r"""
 *TrackStar Developer's Documentation*
 

--- a/trackstar/docs/apiref.py
+++ b/trackstar/docs/apiref.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .config import _CONFIG_
 from inspect import signature

--- a/trackstar/docs/benchmarks.py
+++ b/trackstar/docs/benchmarks.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from trackstar import benchmarks
 

--- a/trackstar/docs/clib.py
+++ b/trackstar/docs/clib.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import textwrap

--- a/trackstar/docs/config.py
+++ b/trackstar/docs/config.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 import trackstar
 import trackstar.exceptions

--- a/trackstar/exceptions.py
+++ b/trackstar/exceptions.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 r"""
 Special ``Warning`` and ``Exception`` classes.
 """

--- a/trackstar/version.py
+++ b/trackstar/version.py
@@ -3,7 +3,7 @@
 # This file is part of the TrackStar package.
 # Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
 # License: MIT License. See LICENSE in top-level directory
-# at: https://github.com/giganano/trackstar.git.
+# at: https://github.com/giganano/TrackStar.git.
 
 from .exceptions import VersionWarning, VersionError
 import importlib.metadata


### PR DESCRIPTION
This merge procedurally syncs up each of the copyright statements at the top of each file. Many files had the link to the repository as https://github.com/giganano/trackstar.git, when the proper form is https://github.com/giganano/TrackStar.git.