### PR TITLE
Copying test infrastructure changes to development branch

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -1,0 +1,46 @@
+# This file is part of the TrackStar package.
+# Copyright (C) 2023 James W. Johnson (giganano9@gmail.com)
+# License: MIT License. See LICENSE in top-level directory
+# at: https://github.com/giganano/TrackStar.git.
+#
+# This workflow creates a source distribution for uploading to PyPI, uploading
+# the .tar.gz file to GitHub actions as an artifact. We upload the source
+# distribution to PyPI manually.
+
+name: Source Distribution
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sdist:
+    name: Source Distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Distribution Requirements
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build>=1.0.0
+          python -m pip install wheel>=0.33.0
+
+      - name: Create Source Distribution
+        shell: bash
+        run: |
+          python -m build --sdist
+
+      - name: Upload Source Distribution
+        uses: actions/upload-artifact@v4
+        with:
+            name: sdist
+            path: ./dist/*.tar.gz
+            retention-days: 1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,6 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - dev
         - docs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,6 @@ docs = [ # see also docs/src/conf.py
 [project.urls]
 Repository = "https://github.com/giganano/TrackStar"
 Issues = "https://github.com/giganano/TrackStar/issues"
+
+[tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]

--- a/trackstar/core/tests/test_covariance_matrix.py
+++ b/trackstar/core/tests/test_covariance_matrix.py
@@ -7,10 +7,15 @@
 
 from trackstar import datum, covariance_matrix
 from trackstar.core.datum import datum_extra
-from trackstar.core.tests.test_datum import _TEST_DATUM_
 import numpy as np
 import numbers
 import pytest
+
+_TEST_DATUM_ = {
+	"x": np.random.random(),
+	"y": np.random.random(),
+	"z": np.random.random()
+}
 
 class TestCovarianceMatrix:
 

--- a/trackstar/tests/__init__.py
+++ b/trackstar/tests/__init__.py
@@ -2,13 +2,11 @@
 try:
 	import pytest
 except ModuleNotFoundError:
-	raise RuntimeError("""\
-pytest is required to run TrackStar's unit tests (https://docs.pytest.org/).""")
+	pass
 try:
 	import numpy as np
 except:
-	raise RuntimeError("""\
-NumPy is required to run TrackStar's unit tests (https://numpy.org/).""")
+	pass
 
 
 def test(*args, **kwargs):
@@ -33,5 +31,9 @@ def test(*args, **kwargs):
 	This function does nothing more than invoke
 	``pytest.main(["--pyargs", "trackstar"], \*args, \*\*kwargs)``.
 	"""
+	if "pytest" not in sys.modules: raise RuntimeError("""\
+pytest is required to run TrackStar's unit tests (https://docs/pytest.org/).""")
+	if "numpy" not in sys.modules: raise RuntimeError("""\
+NumPy is required to run TrackStar's unit tests (https://numpy.org/).""")
 	return pytest.main(["--pyargs", "trackstar"], *args, **kwargs)
 

--- a/trackstar/tests/__init__.py
+++ b/trackstar/tests/__init__.py
@@ -7,6 +7,7 @@ try:
 	import numpy as np
 except:
 	pass
+import sys
 
 
 def test(*args, **kwargs):

--- a/trackstar/tests/__init__.py
+++ b/trackstar/tests/__init__.py
@@ -31,7 +31,7 @@ def test(*args, **kwargs):
 	Notes
 	-----
 	This function does nothing more than invoke
-	``pytest.main(\*args, \*\*kwargs)``.
+	``pytest.main(["--pyargs", "trackstar"], \*args, \*\*kwargs)``.
 	"""
-	return pytest.main(*args, **kwargs)
+	return pytest.main(["--pyargs", "trackstar"], *args, **kwargs)
 


### PR DESCRIPTION
Changes were made to the testing infrastructure for the purpose of distribution. These changes helped ensure that pytest did not create any unnecessaary .pyc files, which allows the entire trackstar directory to be removed from site-packages when uninstalling. Without these modifications, the path would often import the incomplete library from site-packages when later installing in developer's mode, because the old directory was still present. These changes should be reflected in the development branch.

In order to avoid this conflict in the future, new tests should not import code from existing tests, because it causes pytest to create additional .pyc files, which was the root of this problem.